### PR TITLE
Persist slider mappings across reboots with device discovery control

### DIFF
--- a/lib/nativmix/gui/settings_panel.py
+++ b/lib/nativmix/gui/settings_panel.py
@@ -276,7 +276,12 @@ class SettingsPanel(QGroupBox):
 
         self._port_box = QComboBox()
         self._port_box.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-        self._port_box.setToolTip("Select USB port.")
+        self._port_box.setEditable(True)
+        self._port_box.setToolTip(
+            "Select or manually enter a USB port path.\n"
+            "Examples: /dev/ttyUSB0, /dev/ttyACM0, /dev/deej (symlinked device)\n"
+            "Leave empty or select 'Auto-detect' for automatic discovery."
+        )
         self._populate_ports()
         top_layout.addWidget(self._port_box)
 
@@ -419,6 +424,15 @@ class SettingsPanel(QGroupBox):
             self._show_invert_cb.toggled.connect(self._on_show_invert_toggled)
             bottom_layout.addWidget(self._show_invert_cb)
 
+            self._auto_search_cb = QCheckBox("Auto-discover Device")
+            self._auto_search_cb.setToolTip(
+                "If enabled, nativmix will search for Arduino devices on startup even if a port is configured.\n"
+                "Disable this if you have multiple devices and want to use only the configured port."
+            )
+            self._auto_search_cb.setChecked(self._config.auto_search_device)
+            self._auto_search_cb.toggled.connect(self._on_auto_search_toggled)
+            bottom_layout.addWidget(self._auto_search_cb)
+
             bottom_layout.addStretch()
 
             root_layout.addLayout(bottom_layout)
@@ -499,7 +513,9 @@ class SettingsPanel(QGroupBox):
 
         self._input_mode_box.currentIndexChanged.connect(self._on_input_mode_changed)
         self._midi_box.currentIndexChanged.connect(self._on_midi_device_selected)
+        # For the editable port box: connect both index changes and text edits
         self._port_box.currentIndexChanged.connect(self._on_port_selected)
+        self._port_box.editTextChanged.connect(self._on_port_text_changed)
         self._update_hardware_ui_state()
 
 
@@ -535,10 +551,14 @@ class SettingsPanel(QGroupBox):
         self._populate_ports(restore=port or self._port_box.currentData())
 
     def _populate_ports(self, restore: str | None = None) -> None:
-        """Rebuild the combo box from currently available real serial ports."""
+        """Rebuild the combo box from currently available real serial ports.
+        
+        Preserves any manually entered custom port path when refreshing.
+        """
         self._port_box.blockSignals(True)
         if restore is None:
-            restore = self._port_box.currentData() or self._config.hardware_port
+            # Preserve the current text (either from selection or manual entry)
+            restore = self._port_box.currentText().strip() or self._config.hardware_port
 
         self._port_box.clear()
         self._port_box.addItem("Auto-detect", userData=None)
@@ -551,10 +571,18 @@ class SettingsPanel(QGroupBox):
                 label += f"  ({info.description})"
             self._port_box.addItem(label, userData=info.device)
 
+        # Restore the previous selection/text, supporting both discovered and custom ports
         if restore:
+            # First try to find it in the discovered ports (by data)
             idx = self._port_box.findData(restore)
             if idx >= 0:
                 self._port_box.setCurrentIndex(idx)
+            else:
+                # Not in discovered ports - it's a custom manual entry
+                # Set the text directly in the editable combo box
+                self._port_box.setEditText(restore)
+        else:
+            self._port_box.setCurrentIndex(0)  # Auto-detect
 
         self._port_box.blockSignals(False)
 
@@ -651,11 +679,22 @@ class SettingsPanel(QGroupBox):
 
     @pyqtSlot(int)
     def _on_port_selected(self, index: int) -> None:
+        # When selection changes from the dropdown, use the item data
         port = self._port_box.itemData(index)   # None = Auto
+        # Convert None to empty string for consistency
+        if port is None:
+            self._port_box.setEditText("")
+        else:
+            self._port_box.setEditText(port)
+
+    @pyqtSlot(str)
+    def _on_port_text_changed(self, text: str) -> None:
+        # When user manually types or edits the port text
+        port = text.strip() if text.strip() else None  # Empty string → None (auto-detect)
         self._config.hardware_port = port
         self._config.save()
         self.port_changed.emit(port or "")
-        logger.debug("Port selection changed: %s", port or "auto")
+        logger.debug("Port text changed: %s", port or "auto")
 
     @pyqtSlot(int)
     def _on_baud_rate_changed(self, index: int) -> None:
@@ -731,6 +770,12 @@ class SettingsPanel(QGroupBox):
         self._config.show_invert_option = checked
         self._config.save()
         logger.debug("Show Invert Option toggled: %s", checked)
+
+    @pyqtSlot(bool)
+    def _on_auto_search_toggled(self, checked: bool) -> None:
+        self._config.auto_search_device = checked
+        self._config.save()
+        logger.debug("Auto-discover Device toggled: %s", checked)
 
     @pyqtSlot(int)
     def _on_curve_changed(self, slider_value: int) -> None:

--- a/lib/nativmix/hardware/arduino.py
+++ b/lib/nativmix/hardware/arduino.py
@@ -179,6 +179,7 @@ class ArduinoThread(QThread):
         threshold: float = VOLUME_THRESHOLD,
         input_mode: str = "usb",
         baud_rate: int = BAUD_RATE,
+        auto_search_device: bool = True,
         parent=None,
     ) -> None:
         """
@@ -190,6 +191,10 @@ class ArduinoThread(QThread):
                           ``num_channels`` if provided. Defaults to all False.
             threshold:    Minimum volume delta [0.0–1.0] that triggers a signal
                           emit. Loaded from ConfigManager at start-up.
+            input_mode:   "usb", "hybrid", or "midi_only" for input mode.
+            baud_rate:    Serial baud rate (default 9600).
+            auto_search_device: If False, use only the configured port (disable auto-discovery).
+                          If True, try auto-detection even with a port configured.
             parent:       Optional Qt parent object.
         """
         super().__init__(parent)
@@ -197,6 +202,7 @@ class ArduinoThread(QThread):
         self._num_channels: int = num_channels
         self._threshold: float = threshold
         self._baud_rate: int = baud_rate
+        self._auto_search_device: bool = auto_search_device
         self._running: bool = False
         self._reconnect_requested: bool = False
         self._connected_port: str | None = None  # last successfully connected port
@@ -245,21 +251,26 @@ class ArduinoThread(QThread):
         Reload global settings from a ConfigManager instance.
 
         Called safely from the main thread when ConfigManager.settings_changed fires.
-        Syncs threshold, all inversion flags, and the volume exponent immediately.
+        Syncs threshold, all inversion flags, the volume exponent, and auto-search settings.
         """
         old_mode = self._input_mode
         old_baud = self._baud_rate
+        old_auto_search = self._auto_search_device
         self._threshold = config.threshold
         self._input_mode = config.input_mode
         self._baud_rate = config.baud_rate
+        self._auto_search_device = config.auto_search_device
 
-        # If mode or baud rate changed, force reconnect to re-open the serial port
+        # If mode, baud rate, or auto-search setting changed, force reconnect to re-open the serial port
         if old_mode != self._input_mode:
             self._reconnect_requested = True
             logger.debug("ArduinoThread: Mode changed (%s -> %s), re-evaluating session", old_mode, self._input_mode)
         elif old_baud != self._baud_rate:
             self._reconnect_requested = True
             logger.debug("ArduinoThread: Baud rate changed (%d -> %d), reconnecting", old_baud, self._baud_rate)
+        elif old_auto_search != self._auto_search_device:
+            self._reconnect_requested = True
+            logger.debug("ArduinoThread: Auto-search changed (%s -> %s), reconnecting", old_auto_search, self._auto_search_device)
 
         exponent = config.get_volume_exponent()
         with self._channels_lock:
@@ -286,6 +297,21 @@ class ArduinoThread(QThread):
         self._port = port
         self._reconnect_requested = True
         logger.debug("Port switch requested: %s", port or "auto")
+
+    def set_auto_search_device(self, enable: bool) -> None:
+        """
+        Enable or disable automatic device discovery.
+
+        If disabled (False) and a port is configured, only that port will be used.
+        If enabled (True), auto-discovery proceeds even with a configured port.
+
+        Args:
+            enable: True to enable auto-discovery, False to disable it.
+        """
+        self._auto_search_device = enable
+        # Force reconnection to re-evaluate port selection
+        self._reconnect_requested = True
+        logger.debug("Auto-search device: %s", "enabled" if enable else "disabled")
 
     @property
     def current_port(self) -> str | None:
@@ -388,14 +414,35 @@ class ArduinoThread(QThread):
         """
         Determine which serial port to use.
 
-        Order of preference:
+        Order of preference when auto_search_device is True (auto-discovery enabled):
         1. User-configured port (self._port), if the device file exists.
         2. Ports from DEFAULT_PORTS that exist on the filesystem.
         3. First USB-serial port detected by pyserial's list_ports.
 
+        When auto_search_device is False (auto-discovery disabled):
+        1. ONLY the user-configured port (self._port) if it exists.
+        2. None if the port doesn't exist or is None.
+
         Returns:
             Device path string, or None if nothing is found.
         """
+        # If auto-search is disabled and a port is configured, use only that port
+        if not self._auto_search_device:
+            if self._port:
+                if os.path.exists(self._port):
+                    logger.info("Using configured port: %s (auto-discovery disabled)", self._port)
+                    return self._port
+                else:
+                    logger.warning(
+                        "Configured port %s does not exist and auto-discovery is disabled",
+                        self._port
+                    )
+                    return None
+            else:
+                logger.debug("No port configured and auto-discovery is disabled")
+                return None
+
+        # Auto-discovery enabled: proceed with standard port resolution
         # 1) User-configured port
         if self._port and os.path.exists(self._port):
             return self._port

--- a/lib/nativmix/main.py
+++ b/lib/nativmix/main.py
@@ -462,6 +462,7 @@ def main() -> None:
         threshold=config.threshold,
         input_mode=config.input_mode,
         baud_rate=config.baud_rate,
+        auto_search_device=config.auto_search_device,
     )
 
     # ── MIDI thread ─────────────────────────────────────────────────────

--- a/lib/nativmix/utils/config_manager.py
+++ b/lib/nativmix/utils/config_manager.py
@@ -4,12 +4,13 @@ Configuration manager for NativMix.
 Implements Rule 14: XDG-standard config path on Linux
 (~/.config/nativmix/config.json), AppData on Windows (future).
 
-Schema (v5)
+Schema (v6)
 -----------
 {
-    "version": 5,
+    "version": 6,
     "hardware": {
         "port": "/dev/ttyACM0",   // null = auto-detect
+        "auto_search_device": true, // if false, use port exclusively (no auto-discovery)
         "num_channels": 5,
         "input_mode": "usb",      // "usb" | "hybrid" | "midi_only"
         "midi_device": "",
@@ -49,6 +50,7 @@ Migration history:
   v2→v3: added settings.transparency, settings.stay_open
   v3→v4: added settings.debug_logging
   v4→v5: added MIDI fields, v_sink, volume, label, compact_mode
+  v5→v6: added hardware.auto_search_device flag
 """
 
 from __future__ import annotations
@@ -65,7 +67,7 @@ from nativmix.utils.paths import get_config_dir as _get_config_dir_from_paths
 
 logger = logging.getLogger(__name__)
 
-CONFIG_VERSION = 5
+CONFIG_VERSION = 6
 
 # App names that have special routing semantics and cannot be mixed with regular apps.
 SPECIAL_APPS: frozenset[str] = frozenset({"system master", "other apps"})
@@ -104,6 +106,7 @@ def _default_config(num_channels: int = 5) -> dict[str, Any]:
         "version": CONFIG_VERSION,
         "hardware": {
             "port": None,         # None → auto-detect
+            "auto_search_device": True,  # True → try to auto-detect even with port set
             "num_channels": num_channels,
             "input_mode": "usb",  # "usb", "hybrid", "midi_only"
             "midi_device": "",
@@ -293,6 +296,15 @@ class ConfigManager(QObject):
             ch.setdefault("mode", "app")
             ch.setdefault("hardware_id", None)
 
+        # v5 → v6: add auto_search_device flag
+        # If a port is already configured, disable auto-search by default (preserve existing
+        # device setting). If no port is configured, keep auto-search enabled (auto-detect mode).
+        hw = self._data.setdefault("hardware", {})
+        if "auto_search_device" not in hw:
+            # If port is set, disable auto-search to prevent overriding the configured device
+            hw["auto_search_device"] = hw.get("port") is None
+            logger.debug("Migrated auto_search_device: %s (port=%s)", hw["auto_search_device"], hw.get("port"))
+
         self._data["version"] = CONFIG_VERSION
         # Ensure is_midi flags are correct for all channels after migration.
         self._ensure_channels(self.num_channels)
@@ -310,6 +322,25 @@ class ConfigManager(QObject):
     @hardware_port.setter
     def hardware_port(self, port: str | None) -> None:
         self._data.setdefault("hardware", {})["port"] = port
+        # When a port is explicitly set, automatically disable auto-search to prevent
+        # connection to the wrong device (fixes the slider reset bug).
+        # When port is set to None, re-enable auto-search.
+        self._data.setdefault("hardware", {})["auto_search_device"] = port is None
+        logger.debug("Port set to %s (auto_search_device: %s)", port, port is None)
+
+    @property
+    def auto_search_device(self) -> bool:
+        """
+        If True, nativmix performs auto-discovery at startup even when a port is configured.
+        If False, nativmix uses the configured port exclusively without auto-discovery.
+        Default: True (auto-detect behavior for backwards compatibility).
+        """
+        return bool(self._data.get("hardware", {}).get("auto_search_device", True))
+
+    @auto_search_device.setter
+    def auto_search_device(self, value: bool) -> None:
+        self._data.setdefault("hardware", {})["auto_search_device"] = bool(value)
+        self.settings_changed.emit()
 
     @property
     def baud_rate(self) -> int:


### PR DESCRIPTION
feat: Persist slider mappings across reboots with device discovery control

- Add auto_search_device config flag (v5→v6 migration)
- Disable auto-discovery when port is configured
- Make port selector editable for manual/symlinked devices
- Add GUI toggle for discovery behavior
- Fixes #8