### PR TITLE
Fix GNOME Shell FIFO growth from redundant Pulse volume writes

### DIFF
--- a/lib/nativmix/audio/manager.py
+++ b/lib/nativmix/audio/manager.py
@@ -603,6 +603,12 @@ class PipeWireManager(AudioBackendBase):
         # leading to gradual RSS growth.  Lazily initialised on first use;
         # reconnected transparently on PulseError.
         self._vol_pulse: pulsectl.Pulse | None = None
+        # Last volume sent to each Pulse target. Arduino emits a full channel
+        # snapshot when any fader changes, so without this guard one noisy or
+        # active fader re-applies every other channel on each tick. On GNOME,
+        # repeated master/hardware sink writes can put pressure on gnome-shell
+        # via volume-change handling even when the effective volume is unchanged.
+        self._last_applied_volumes: dict[tuple[str, str], float] = {}
         # Debounce rapid stream add/remove events: coalesces multiple events
         # within 50 ms into a single get_active_streams() call.
         self._stream_refresh_timer = QTimer(self)
@@ -920,6 +926,7 @@ class PipeWireManager(AudioBackendBase):
             except Exception:
                 pass
             self._vol_pulse = None
+        self._last_applied_volumes.clear()
         logger.debug("PipeWireManager stopped")
 
     def _get_vol_pulse(self) -> pulsectl.Pulse | None:
@@ -936,6 +943,15 @@ class PipeWireManager(AudioBackendBase):
         except Exception:
             self._vol_pulse = None
             return None
+
+    def _should_apply_volume(self, target_type: str, target_id: str, volume: float) -> bool:
+        """Return True if a target volume materially changed since our last write."""
+        key = (target_type, target_id.lower())
+        previous = self._last_applied_volumes.get(key)
+        if previous is not None and abs(previous - volume) < 0.001:
+            return False
+        self._last_applied_volumes[key] = volume
+        return True
 
     def _check_tools(self) -> dict[str, bool]:
         """Check availability of required system tools (pactl, pw-link)."""
@@ -1312,15 +1328,17 @@ class PipeWireManager(AudioBackendBase):
                 mode = self._config.get_channel_mode(channel)
                 if mode == "hardware":
                     hw_id = self._config.get_hardware_id(channel)
-                    if hw_id:
-                        self._apply_hardware_volume(hw_id, volume)
+                    if hw_id and self._should_apply_volume("hardware", hw_id, volume):
+                        self._apply_hardware_volume(hw_id, volume, pulse=shared_pulse)
                 else:
                     if self._config.is_v_sink_enabled(channel):
-                        self._set_v_sink_volume(channel, volume, pulse=shared_pulse)
+                        if self._should_apply_volume("vsink", str(channel), volume):
+                            self._set_v_sink_volume(channel, volume, pulse=shared_pulse)
                     else:
                         app_names = self._config.get_app_names(channel)
                         for name in app_names:
-                            self._apply_volume_by_name(name, volume, pulse=shared_pulse)
+                            if self._should_apply_volume("app", name, volume):
+                                self._apply_volume_by_name(name, volume, pulse=shared_pulse)
         except pulsectl.PulseError as exc:
             logger.error("apply_poti_volumes: PulseAudio connection lost: %s", exc)
             try:
@@ -1328,6 +1346,7 @@ class PipeWireManager(AudioBackendBase):
             except Exception:
                 pass
             self._vol_pulse = None  # force reconnect on next tick
+            self._last_applied_volumes.clear()
 
         self._update_thread_states()
 
@@ -1369,21 +1388,24 @@ class PipeWireManager(AudioBackendBase):
                 mode = self._config.get_channel_mode(channel)
                 if mode == "hardware":
                     hw_id = self._config.get_hardware_id(channel)
-                    if hw_id:
-                        self._apply_hardware_volume(hw_id, volume)
+                    if hw_id and self._should_apply_volume("hardware", hw_id, volume):
+                        self._apply_hardware_volume(hw_id, volume, pulse=shared_pulse)
                 else:
                     if self._config.is_v_sink_enabled(channel):
-                        self._set_v_sink_volume(channel, volume, pulse=shared_pulse)
+                        if self._should_apply_volume("vsink", str(channel), volume):
+                            self._set_v_sink_volume(channel, volume, pulse=shared_pulse)
                     else:
                         app_names = self._config.get_app_names(channel)
                         for name in app_names:
-                            self._apply_volume_by_name(name, volume, pulse=shared_pulse)
+                            if self._should_apply_volume("app", name, volume):
+                                self._apply_volume_by_name(name, volume, pulse=shared_pulse)
         except pulsectl.PulseError as exc:
             try:
                 self._vol_pulse.disconnect()
             except Exception:
                 pass
             self._vol_pulse = None  # force reconnect on next tick
+            self._last_applied_volumes.clear()
             logger.error("apply_midi_volumes: PulseAudio connection lost: %s", exc)
 
         self._update_thread_states()
@@ -1409,15 +1431,17 @@ class PipeWireManager(AudioBackendBase):
 
         if mode == "hardware":
             hw_id = self._config.get_hardware_id(channel_index)
-            if hw_id:
+            if hw_id and self._should_apply_volume("hardware", hw_id, volume):
                 self._apply_hardware_volume(hw_id, volume)
         else:
             if self._config.is_v_sink_enabled(channel_index):
-                self._set_v_sink_volume(channel_index, volume) # Slider can open its own connection
+                if self._should_apply_volume("vsink", str(channel_index), volume):
+                    self._set_v_sink_volume(channel_index, volume) # Slider can open its own connection
             else:
                 app_names = self._config.get_app_names(channel_index)
                 for name in app_names:
-                    self._apply_volume_by_name(name, volume)
+                    if self._should_apply_volume("app", name, volume):
+                        self._apply_volume_by_name(name, volume)
 
         self._update_thread_states()
 
@@ -1550,21 +1574,32 @@ class PipeWireManager(AudioBackendBase):
         except pulsectl.PulseError as exc:
             logger.error("apply_volume_by_name('%s', %.2f) failed: %s", app_name, volume, exc)
 
-    def _apply_hardware_volume(self, hw_id: str, volume: float) -> None:
+    def _apply_hardware_volume(
+        self,
+        hw_id: str,
+        volume: float,
+        pulse: pulsectl.Pulse | None = None,
+    ) -> None:
         """Apply hardware volume directly to a specific sink or source."""
-        try:
+        def _do_apply(p: pulsectl.Pulse) -> None:
             parts = hw_id.split(':', 1)
             if len(parts) != 2:
                 return
             kind, name = parts
 
-            with pulsectl.Pulse("nativmix-hw-vol") as pulse:
-                if kind == "sink":
-                    dev = pulse.get_sink_by_name(name)
-                    pulse.volume_set_all_chans(dev, volume)
-                elif kind == "source":
-                    dev = pulse.get_source_by_name(name)
-                    pulse.volume_set_all_chans(dev, volume)
+            if kind == "sink":
+                dev = p.get_sink_by_name(name)
+                p.volume_set_all_chans(dev, volume)
+            elif kind == "source":
+                dev = p.get_source_by_name(name)
+                p.volume_set_all_chans(dev, volume)
+
+        try:
+            if pulse is not None:
+                _do_apply(pulse)
+            else:
+                with pulsectl.Pulse("nativmix-hw-vol") as p:
+                    _do_apply(p)
         except pulsectl.PulseError as exc:
             logger.error("Failed to apply hardware volume to %s: %s", hw_id, exc)
 

--- a/lib/nativmix/hardware/arduino.py
+++ b/lib/nativmix/hardware/arduino.py
@@ -620,6 +620,14 @@ class ArduinoThread(QThread):
                 self._adapt_channels(n)
                 self.channel_count_changed.emit(n)
                 self._pending_count_stable = 0
+            else:
+                logger.debug(
+                    "Ignoring transient channel count %d (expected %d, stable=%d/3)",
+                    n,
+                    self._num_channels,
+                    self._pending_count_stable,
+                )
+                return
         else:
             self._pending_count = n
             self._pending_count_stable = 0

--- a/tests/test_arduino.py
+++ b/tests/test_arduino.py
@@ -1,0 +1,38 @@
+from nativmix.hardware.arduino import ArduinoThread
+
+
+def test_transient_larger_channel_count_is_discarded_without_index_error():
+    thread = ArduinoThread(num_channels=2)
+    emitted: list[list[float]] = []
+    thread.volumes_changed.connect(emitted.append)
+
+    thread._process_line("1|2|3")
+    thread._process_line("4|5|6")
+
+    assert thread._num_channels == 2
+    assert len(thread._channels) == 2
+    assert emitted == []
+
+
+def test_channel_count_adapts_after_three_stable_clean_frames():
+    thread = ArduinoThread(num_channels=2)
+    counts: list[int] = []
+    thread.channel_count_changed.connect(counts.append)
+
+    thread._process_line("1|2|3")
+    thread._process_line("4|5|6")
+    thread._process_line("7|8|9")
+
+    assert thread._num_channels == 3
+    assert len(thread._channels) == 3
+    assert counts == [3]
+
+
+def test_malformed_channel_count_candidate_does_not_reset_channels():
+    thread = ArduinoThread(num_channels=2)
+
+    thread._process_line("1|2|oops")
+    thread._process_line("3|4")
+
+    assert thread._num_channels == 2
+    assert len(thread._channels) == 2


### PR DESCRIPTION
This fixes #19 issue where adjusting volume through NativMix could cause GNOME Shell to continuously accumulate FIFO/pipe file descriptors.

The root cause was excessive PulseAudio/PipeWire volume writes:
  - Arduino volume events contain a full channel snapshot.
  - When one fader changed, NativMix re-applied volumes for other unchanged channels too.
  - Hardware/system volume paths also opened a fresh Pulse connection per update instead of reusing the persistent volume connection.
  - On GNOME, repeated system/hardware volume writes appear to trigger shell-side FIFO allocation via volume-change handling.

This PR reduces that pressure by skipping unchanged volume writes and reusing the persistent Pulse connection for hardware sink/source volume changes.

## Changes
  - Add per-target volume deduplication in PipeWireManager.
  - Reuse the persistent Pulse connection for hardware volume writes during Arduino/MIDI ticks.
  - Clear the dedupe cache when the persistent Pulse connection is reset.
  - Fix Arduino transient channel-count handling so mismatched reconnect frames are discarded until stable.
  - Add regression tests for Arduino channel-count mismatch handling.

## Testing
Ran:
` PYTHONPATH=lib python -m pytest tests/test_arduino.py tests/test_config_migration.py
`  
**Result:**
11 passed

Also manually verified that the GNOME Shell FIFO count no longer grows continuously while changing volume through NativMix.